### PR TITLE
Add global minor mode.

### DIFF
--- a/fira-code-mode.el
+++ b/fira-code-mode.el
@@ -165,6 +165,9 @@ option; if \"x\" is disabled but this option is enabled, then strings like
       (fira-code-mode--enable)
     (fira-code-mode--disable)))
 
+;;;###autoload
+(define-globalized-minor-mode global-fira-code-mode fira-code-mode
+  fira-code-mode)
 
 ;; Extra utility functions
 (defun fira-code-mode--setup ()


### PR DESCRIPTION
This provides a standard way to globally enable the mode without manually using hooks.