### PR TITLE
Add fira-code-mode-install-fonts command for Linux and mac OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,13 @@ You don't need to use Fira Code as your main font in Emacs for this to work! Usi
 
 ## Getting Started
 
-1. Install the Fira Code Symbol font to your system ([Download](https://raw.githubusercontent.com/jming422/fira-code-mode/master/fonts/FiraCode-Regular-Symbol.otf)) ([Original post](https://github.com/tonsky/FiraCode/issues/211#issuecomment-239058632)).
-   - If you don't know how to install a font to your system, check out Fira Code's main repo. They have some [good instructions here](https://github.com/tonsky/FiraCode/wiki/Installing).
-   - *Note:* This Fira Code Symbol font is not the same as the real Fira Code font, and you need to install Fira Code Symbol whether you have regular Fira Code on your system or not.
-   - Thanks to [@siegebell](https://github.com/siegebell) for creating this font.
+1. Install `fira-code-mode`. (from MELPA: `M-x package-install RET fira-code-mode RET`)
 
-2. Install `fira-code-mode`. (from MELPA: `M-x package-install RET fira-code-mode RET`)
+2. Install the `Fira Code Symbol` font to your system by `M-x fira-code-mode-install-fonts RET`
+   - Or you can install the font manually. Download the font [here](https://raw.githubusercontent.com/jming422/fira-code-mode/master/fonts/FiraCode-Regular-Symbol.otf)
+     and follow the instructions [here](https://github.com/tonsky/FiraCode/wiki/Installing).
+   - *Note:* This `Fira Code Symbol` font is not the same as the real `Fira Code` font, and you need to install `Fira Code Symbol` whether you have regular `Fira Code` on your system or not.
+   - Thanks to [@siegebell](https://github.com/siegebell) for creating this font.
 
 3. Enable `fira-code-mode` in your config, either using `(global-fira-code-mode)` or by adding `fira-code-mode` to whichever hooks you like.
 

--- a/fira-code-mode.el
+++ b/fira-code-mode.el
@@ -36,6 +36,7 @@
 ;; https://github.com/tonsky/FiraCode/issues/211#issuecomment-239058632
 
 ;;; Code:
+(require 'cl-lib)
 
 ;; Customizable variables:
 (defgroup fira-code-ligatures nil
@@ -178,6 +179,28 @@ will ensure that this range is resolved using the Fira Code Symbol font instead.
   (set-fontset-font t '(#Xe100 . #Xe16f) "Fira Code Symbol")
   (message "Finished setting up the Fira Code Symbol font."))
 
+;;;###autoload
+(defun fira-code-mode-install-fonts (&optional pfx)
+  "Helper function to download and install the latests fonts based on OS.
+When PFX is non-nil, ignore the prompt and just install"
+  (interactive "P")
+  (when (or pfx (yes-or-no-p "This will download and install fonts, are you sure you want to do this?"))
+    (let* ((font-url "https://raw.githubusercontent.com/jming422/fira-code-mode/master/fonts/FiraCode-Regular-Symbol.otf")
+           (font-dest (cl-case window-system
+                        (x (if (getenv "XDG_DATA_HOME")
+                               (expand-file-name "fonts/" (getenv "XDG_DATA_HOME"))
+                             (expand-file-name ".local/share/fonts/" (getenv "HOME"))))
+                        (ns (expand-file-name "Library/Fonts/" (getenv "HOME")))))
+           (known-dest? (stringp font-dest))
+           (font-dest (or font-dest (read-directory-name "Font installation directory: " "~/"))))
+      (unless (file-directory-p font-dest) (mkdir font-dest t))
+      (url-copy-file font-url (expand-file-name (file-name-nondirectory font-url) font-dest) t)
+      (when known-dest?
+        (message "Fonts downloaded, updating font cache... <fc-cache -f -v> ")
+        (shell-command-to-string (format "fc-cache -f -v")))
+      (message "Successfully %s `fira-code-mode' fonts to `%s'!"
+               (if known-dest? "installed" "downloaded")
+               font-dest))))
 
 (provide 'fira-code-mode)
 ;;; fira-code-mode.el ends here


### PR DESCRIPTION
This PR adds M-x fira-code-mode-install-fonts command which automatically installs required fonts.
The font file is attached to #9 of this repository and gzip compressed.
The command downloads it, decompress it and runs fc-cache command.
